### PR TITLE
New chart for the X.509 Prometheus exporter

### DIFF
--- a/charts/x509-exporter/.helmignore
+++ b/charts/x509-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/x509-exporter/Chart.yaml
+++ b/charts/x509-exporter/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: x509-exporter
+description: Prometheus exporter for X.509 certificates enabling expiration monitoring
+type: application
+version: 0.1.0
+appVersion: 1.5.2
+home: https://github.com/enix/x509-exporter
+sources:
+  - https://github.com/enix/helm-charts/tree/master/charts/x509-exporter
+  - https://github.com/enix/x509-exporter
+maintainers:
+  - name: Thibault Vincent
+    email: root@paraneko.org
+    url: https://github.com/npdgm

--- a/charts/x509-exporter/README.md
+++ b/charts/x509-exporter/README.md
@@ -1,0 +1,171 @@
+x509-exporter
+=============
+
+<p align="center">
+    <a href="https://opensource.org/licenses/Apache-2.0" alt="Apache 2.0 License">
+        <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" /></a>
+    <a href="https://enix.io/fr/blog/" alt="Brought to you by ENIX">
+        <img src="https://img.shields.io/badge/Brought%20to%20you%20by-ENIX-%23377dff?labelColor=888&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAQAAAC1QeVaAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAAHdElNRQfkBAkQIg/iouK/AAABZ0lEQVQY0yXBPU8TYQDA8f/zcu1RSDltKliD0BKNECYZmpjgIAOLiYtubn4EJxI/AImzg3E1+AGcYDIMJA7lxQQQQRAiSSFG2l457+655x4Gfz8B45zwipWJ8rPCQ0g3+p9Pj+AlHxHjnLHAbvPW2+GmLoBN+9/+vNlfGeU2Auokd8Y+VeYk/zk6O2fP9fcO8hGpN/TUbxpiUhJiEorTgy+6hUlU5N1flK+9oIJHiKNCkb5wMyOFw3V9o+zN69o0Exg6ePh4/GKr6s0H72Tc67YsdXbZ5gENNjmigaXbMj0tzEWrZNtqigva5NxjhFP6Wfw1N1pjqpFaZQ7FAY6An6zxTzHs0BGqY/NQSnxSBD6WkDRTf3O0wG2Ztl/7jaQEnGNxZMdy2yET/B2xfGlDagQE1OgRRvL93UOHqhLnesPKqJ4NxLLn2unJgVka/HBpbiIARlHFq1n/cWlMZMne1ZfyD5M/Aa4BiyGSwP4Jl3UAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjAtMDQtMDlUMTQ6MzQ6MTUrMDI6MDDBq8/nAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDIwLTA0LTA5VDE0OjM0OjE1KzAyOjAwsPZ3WwAAAABJRU5ErkJggg==" /></a>
+</p>
+
+Prometheus exporter for X.509 certificates enabling expiration monitoring
+
+Currently, it will only target files and directories on cluster nodes using
+`hostPath`.
+
+## TL;DR;
+
+For a typical kubeadm deployed cluster with prometheus-operator :
+
+```
+$ cat values.yaml
+exporter:
+  watchFiles:
+    - /var/lib/kubelet/pki/kubelet.crt
+    - /var/lib/kubelet/pki/kubelet-client-current.pem
+  watchDirectories:
+    - /etc/kubernetes/pki/
+  watchKubeconfFiles:
+    - /etc/kubernetes/kubelet.conf
+    - /etc/kubernetes/admin.conf
+prometheusServiceMonitor:
+  create: true
+prometheusRules:
+  create: true
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+
+$ helm repo add enix https://charts.enix.io
+$ helm install my-release enix/x509-exporter -f values.yaml
+```
+
+Source code can be found [here](https://github.com/enix/x509-exporter)
+
+
+
+## Installing the Chart
+
+You'll have to define values as the exporter won't provide any metric when
+using defaults.
+A good starting point is to identify paths for cluster certificates in your
+Kubernetes distribution. Expiration of cluster certificates can cause
+significant outages so you'd want to alerted if renewal is required.
+
+On a kubeadm deployed cluster, we'd want to watch kubelet certificates as
+well as the PKI directory. If your Kubeconfig files also contain embedded
+certificates, it can be passed to the exporter too. Adapt the following to your
+Kubernetes deployment :
+```yaml
+exporter:
+  watchFiles:
+    - /var/lib/kubelet/pki/kubelet.crt
+    - /var/lib/kubelet/pki/kubelet-client-current.pem
+  watchDirectories:
+    - /etc/kubernetes/pki/
+  watchKubeconfFiles:
+    - /etc/kubernetes/kubelet.conf
+    - /etc/kubernetes/admin.conf
+```
+
+When watching cluster certificates, you would also want the x509-exporter
+DaemonSet to be running on master nodes and other control-plane nodes.
+Tolerations have to be set for the NoSchedule effect. Again, on a kubeadm
+cluster you could use :
+```yaml
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+```
+Other distributions such as Rancher Kubernetes Engine (RKE) may require
+additionnal tolerations for master nodes :
+```yaml
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/controlplane
+    operator: Exists
+  - effect: NoExecute
+    key: node-role.kubernetes.io/etcd
+    operator: Exists
+```
+
+For prometheus-operator users, this Chart can install a `ServiceMonitor` and
+a `PrometheusRules` ressources to have the x509-exporter service auto-discovered
+and Alertmanager notify on certificate expiry. Check the
+[Chart Values](#chart-values) for options.
+
+To install the chart with the release name `my-release`:
+
+```
+$ helm install my-release enix/x509-exporter -f values.yaml
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Chart Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | affinity configuration on Pods |
+| exporter.watchDirectories | list | `[]` | Directories to scan for certificates to be watched and exported |
+| exporter.watchFiles | list | `[]` | Certificate files to watch and export metrics about (PEM encoded X.509) |
+| exporter.watchKubeconfFiles | list | `[]` | Kubeconf files scanned for embedded certificates to export metrics about |
+| extraLabels | object | `{}` | Extra labels to add on chart resources |
+| fullnameOverride | string | `""` | String to fully override x509-exporter.fullname template with a string |
+| image.pullPolicy | string | `"IfNotPresent"` | x509-exporter image pull policy |
+| image.repository | string | `"enix/x509-exporter"` | x509-exporter image repository |
+| image.tag | string | `nil` | x509-exporter image version |
+| imagePullSecrets | list | `[]` |  |
+| nameOverride | string | `""` | String to partially override x509-exporter.fullname template with a string (will prepend the release name) |
+| nodeSelector | object | `{}` | nodeSelector configuration on Pods |
+| podSecurityContext | object | `{}` | securityContext configuration on Pods |
+| prometheusRules.create | bool | `false` | Install a PrometheusRule ressource to alert on certificate expiration (for prometheus-operator users) |
+| prometheusRules.criticalDaysLeft | int | `30` | Raise a critical alert when this little days are left before a certificate expiration |
+| prometheusRules.extraLabels | object | `{}` | Extra labels to add on PrometheusRule ressources |
+| prometheusRules.warningDaysLeft | int | `90` | Raise a warning alert when this little days are left before a certificate expiration |
+| prometheusServiceMonitor.create | bool | `false` | Install a ServiceMonitor ressource to scrape this exporter (for prometheus-operator users) |
+| prometheusServiceMonitor.extraLabels | object | `{}` | Extra labels to add on ServiceMonitor ressources |
+| prometheusServiceMonitor.scrapeInterval | string | `"60s"` | Target scrape interval to be set in the ServiceMonitor |
+| rbacProxy.enable | bool | `false` | Use kube-rbac-proxy to expose exporters |
+| rbacProxy.exporterListenPort | int | `9091` | Listen port for the exporter inside kube-rbac-proxy exposed Pods |
+| rbacProxy.imagePullPolicy | string | `"IfNotPresent"` | kube-rbac-proxy image pull policy |
+| rbacProxy.imageRepository | string | `"quay.io/coreos/kube-rbac-proxy"` | kube-rbac-proxy image repository |
+| rbacProxy.imageTag | string | `"v0.4.1"` | kube-rbac-proxy image version |
+| resources | object | `{}` | resources configuration on Pods |
+| restartPolicy | string | `"Always"` | Pods restart policy |
+| securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | securityContext configuration on x509-exporter containers |
+| servicePort | int | `9090` |  |
+| tolerations | list | `[]` | tolerations configuration on Pods |
+| updateStrategy | object | `{}` | updateStrategy configuration on Pods |
+
+## License
+
+Copyright (c) 2020 ENIX
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/charts/x509-exporter/README.md.gotmpl
+++ b/charts/x509-exporter/README.md.gotmpl
@@ -1,0 +1,136 @@
+{{ template "chart.header" . }}
+
+<p align="center">
+    <a href="https://opensource.org/licenses/Apache-2.0" alt="Apache 2.0 License">
+        <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" /></a>
+    <a href="https://enix.io/fr/blog/" alt="Brought to you by ENIX">
+        <img src="https://img.shields.io/badge/Brought%20to%20you%20by-ENIX-%23377dff?labelColor=888&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAQAAAC1QeVaAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAAHdElNRQfkBAkQIg/iouK/AAABZ0lEQVQY0yXBPU8TYQDA8f/zcu1RSDltKliD0BKNECYZmpjgIAOLiYtubn4EJxI/AImzg3E1+AGcYDIMJA7lxQQQQRAiSSFG2l457+655x4Gfz8B45zwipWJ8rPCQ0g3+p9Pj+AlHxHjnLHAbvPW2+GmLoBN+9/+vNlfGeU2Auokd8Y+VeYk/zk6O2fP9fcO8hGpN/TUbxpiUhJiEorTgy+6hUlU5N1flK+9oIJHiKNCkb5wMyOFw3V9o+zN69o0Exg6ePh4/GKr6s0H72Tc67YsdXbZ5gENNjmigaXbMj0tzEWrZNtqigva5NxjhFP6Wfw1N1pjqpFaZQ7FAY6An6zxTzHs0BGqY/NQSnxSBD6WkDRTf3O0wG2Ztl/7jaQEnGNxZMdy2yET/B2xfGlDagQE1OgRRvL93UOHqhLnesPKqJ4NxLLn2unJgVka/HBpbiIARlHFq1n/cWlMZMne1ZfyD5M/Aa4BiyGSwP4Jl3UAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjAtMDQtMDlUMTQ6MzQ6MTUrMDI6MDDBq8/nAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDIwLTA0LTA5VDE0OjM0OjE1KzAyOjAwsPZ3WwAAAABJRU5ErkJggg==" /></a>
+</p>
+
+{{ template "chart.description" . }}
+
+Currently, it will only target files and directories on cluster nodes using
+`hostPath`.
+
+## TL;DR;
+
+For a typical kubeadm deployed cluster with prometheus-operator :
+
+```
+$ cat values.yaml
+exporter:
+  watchFiles:
+    - /var/lib/kubelet/pki/kubelet.crt
+    - /var/lib/kubelet/pki/kubelet-client-current.pem
+  watchDirectories:
+    - /etc/kubernetes/pki/
+  watchKubeconfFiles:
+    - /etc/kubernetes/kubelet.conf
+    - /etc/kubernetes/admin.conf
+prometheusServiceMonitor:
+  create: true
+prometheusRules:
+  create: true
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+
+$ helm repo add enix https://charts.enix.io
+$ helm install my-release enix/x509-exporter -f values.yaml
+```
+
+{{ template "chart.sourceLinkLine" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installing the Chart
+
+You'll have to define values as the exporter won't provide any metric when
+using defaults.
+A good starting point is to identify paths for cluster certificates in your
+Kubernetes distribution. Expiration of cluster certificates can cause
+significant outages so you'd want to alerted if renewal is required.
+
+On a kubeadm deployed cluster, we'd want to watch kubelet certificates as
+well as the PKI directory. If your Kubeconfig files also contain embedded
+certificates, it can be passed to the exporter too. Adapt the following to your
+Kubernetes deployment :
+```yaml
+exporter:
+  watchFiles:
+    - /var/lib/kubelet/pki/kubelet.crt
+    - /var/lib/kubelet/pki/kubelet-client-current.pem
+  watchDirectories:
+    - /etc/kubernetes/pki/
+  watchKubeconfFiles:
+    - /etc/kubernetes/kubelet.conf
+    - /etc/kubernetes/admin.conf
+```
+
+When watching cluster certificates, you would also want the x509-exporter
+DaemonSet to be running on master nodes and other control-plane nodes.
+Tolerations have to be set for the NoSchedule effect. Again, on a kubeadm
+cluster you could use :
+```yaml
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+```
+Other distributions such as Rancher Kubernetes Engine (RKE) may require
+additionnal tolerations for master nodes :
+```yaml
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/controlplane
+    operator: Exists
+  - effect: NoExecute
+    key: node-role.kubernetes.io/etcd
+    operator: Exists
+```
+
+For prometheus-operator users, this Chart can install a `ServiceMonitor` and
+a `PrometheusRules` ressources to have the x509-exporter service auto-discovered
+and Alertmanager notify on certificate expiry. Check the
+[Chart Values](#chart-values) for options.
+
+To install the chart with the release name `my-release`:
+
+```
+$ helm install my-release enix/x509-exporter -f values.yaml
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+{{ template "chart.valuesSection" . }}
+
+## License
+
+Copyright (c) 2020 ENIX
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/charts/x509-exporter/templates/_helpers.tpl
+++ b/charts/x509-exporter/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "x509-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "x509-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "x509-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "x509-exporter.labels" -}}
+helm.sh/chart: {{ include "x509-exporter.chart" . }}
+{{ include "x509-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "x509-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "x509-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/x509-exporter/templates/clusterrole.yaml
+++ b/charts/x509-exporter/templates/clusterrole.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbacProxy.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "x509-exporter.fullname" . }}
+  labels:
+    {{- include "x509-exporter.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels }}
+    {{ . | toYaml | trim | nindent 4 }}
+    {{- end }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/charts/x509-exporter/templates/clusterrolebinding.yaml
+++ b/charts/x509-exporter/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbacProxy.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "x509-exporter.fullname" . }}
+  labels:
+    {{- include "x509-exporter.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels }}
+    {{ . | toYaml | trim | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "x509-exporter.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "x509-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/x509-exporter/templates/daemonset.yaml
+++ b/charts/x509-exporter/templates/daemonset.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "x509-exporter.fullname" . }}
+  labels:
+    {{- include "x509-exporter.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels }}
+    {{ . | toYaml | trim | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "x509-exporter.selectorLabels" . | nindent 6 }}
+{{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | trim | nindent 4 }}
+{{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "x509-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | trim | nindent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | trim | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | trim | nindent 8 }}
+    {{- end }}
+      restartPolicy: {{ .Values.restartPolicy }}
+      containers:
+        - name: {{ .Chart.Name }}
+        {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | trim | nindent 12 }}
+        {{- end }}
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+        {{- if not .Values.rbacProxy.enable }}
+          - --port={{ .Values.servicePort }}
+        {{- else }}
+          - --port={{ .Values.rbacProxy.exporterListenPort }}
+        {{- end }}
+        {{- range .Values.exporter.watchDirectories }}
+          - --watch-dir=/mnt/watch/dir-{{ . | clean | sha1sum }}
+        {{- end }}
+        {{- range .Values.exporter.watchFiles }}
+          - --watch-file=/mnt/watch/file-{{ . | clean | sha1sum }}
+        {{- end }}
+        {{- range .Values.exporter.watchKubeconfFiles }}
+          - --watch-kubeconf=/mnt/watch/kube-{{ . | clean | sha1sum }}
+        {{- end }}
+          volumeMounts:
+        {{- range .Values.exporter.watchDirectories }}
+          - name: dir-{{ . | clean | sha1sum }}
+            mountPath: /mnt/watch/dir-{{ . | clean | sha1sum }}
+            readOnly: true
+        {{- end }}
+        {{- range .Values.exporter.watchFiles }}
+          - name: file-{{ . | clean | sha1sum }}
+            mountPath: /mnt/watch/file-{{ . | clean | sha1sum }}
+            subPath: {{ . | base }}
+            readOnly: true
+        {{- end }}
+        {{- range .Values.exporter.watchKubeconfFiles }}
+          - name: kube-{{ . | clean | sha1sum }}
+            mountPath: /mnt/watch/kube-{{ . | clean | sha1sum }}
+            subPath: {{ . | base }}
+            readOnly: true
+        {{- end }}
+    {{- if not .Values.rbacProxy.enable }}
+          ports:
+          - name: metrics
+            containerPort: {{ .Values.servicePort }}
+    {{- else }}
+        - name: kube-rbac-proxy
+          image: "{{ .Values.rbacProxy.repository }}:{{ .Values.rbacProxy.version }}"
+          args:
+          - --logtostderr
+          - -v=99
+          - --upstream=http://[127.0.0.1]:{{ .Values.rbacProxy.exporterListenPort }}
+          - --secure-listen-address=[$(IP)]:{{ .Values.servicePort }}
+          env:
+          - name: IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - name: metrics
+            containerPort: {{ .Values.servicePort }}
+          resources:
+            limits:
+              cpu: 20m
+              memory: 40Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+      serviceAccountName: {{ include "x509-exporter.fullname" . }}
+    {{- end }}
+      volumes:
+    {{- range .Values.exporter.watchDirectories }}
+      - name: dir-{{ . | clean | sha1sum }}
+        hostPath:
+          path: {{ . | clean }}
+    {{- end }}
+    {{- range .Values.exporter.watchFiles }}
+      - name: file-{{ . | clean | sha1sum }}
+        hostPath:
+          path: {{ . | clean | dir }}
+    {{- end }}
+    {{- range .Values.exporter.watchKubeconfFiles }}
+      - name: kube-{{ . | clean | sha1sum }}
+        hostPath:
+          path: {{ . | clean | dir }}
+    {{- end }}

--- a/charts/x509-exporter/templates/prometheusrule.yaml
+++ b/charts/x509-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.prometheusRules.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "x509-exporter.fullname" . }}
+  labels:
+    {{- include "x509-exporter.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels }}
+    {{ . | toYaml | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.prometheusRules.extraLabels }}
+    {{- . | toYaml | trim | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+  - name: kubernetes-certificates.rules
+    rules:
+    - alert: KubernetesCertificateRenewal
+      expr: ((x509_cert_not_after - time()) / 86400) < {{ .Values.prometheusRules.warningDaysLeft }}
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: A Kubernetes certificate should be renewed
+        description: Kubernetes certificate "{{ "{{" }} $labels.subject_CN {{ "}}" }}" should be renewed
+    - alert: KubernetesCertificateExpiration
+      expr: ((x509_cert_not_after - time()) / 86400) < {{ .Values.prometheusRules.criticalDaysLeft }}
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        summary: A Kubernetes certificate is about to expire
+        description: Kubernetes certificate "{{ "{{" }} $labels.subject_CN {{ "}}" }}" is about to expire
+{{- end }}

--- a/charts/x509-exporter/templates/service.yaml
+++ b/charts/x509-exporter/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "x509-exporter.fullname" . }}
+  labels:
+    {{- include "x509-exporter.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels }}
+    {{ . | toYaml | trim | nindent 4 }}
+    {{- end }}
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: {{ .Values.servicePort }}
+      targetPort: metrics
+  selector:
+    {{- include "x509-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/x509-exporter/templates/serviceaccount.yaml
+++ b/charts/x509-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbacProxy.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "x509-exporter.fullname" . }}
+  labels:
+    {{- include "x509-exporter.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels }}
+    {{ . | toYaml | trim | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/x509-exporter/templates/servicemonitor.yaml
+++ b/charts/x509-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.prometheusServiceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "x509-exporter.fullname" . }}
+  labels:
+    {{- include "x509-exporter.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels }}
+    {{ . | toYaml | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.prometheusServiceMonitor.extraLabels }}
+    {{- . | toYaml | trim | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      labels:
+        {{- include "x509-exporter.selectorLabels" . | nindent 4 }}
+  jobLabel: app.kubernetes.io/name
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.prometheusServiceMonitor.scrapeInterval }}
+  {{- if .Values.rbacProxy.enable }}
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  {{- end }}
+{{- end }}

--- a/charts/x509-exporter/values.yaml
+++ b/charts/x509-exporter/values.yaml
@@ -1,0 +1,92 @@
+---
+# Default values for x509-exporter.
+#
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# extraLabels -- Extra labels to add on chart resources
+extraLabels: {}
+
+# nameOverride -- String to partially override x509-exporter.fullname template with a string (will prepend the release name)
+nameOverride: ""
+
+# fullnameOverride -- String to fully override x509-exporter.fullname template with a string
+fullnameOverride: ""
+
+imagePullSecrets: []
+image:
+  # image.repository -- x509-exporter image repository
+  repository: enix/x509-exporter
+  # image.tag -- x509-exporter image version
+  tag:
+  # image.pullPolicy -- x509-exporter image pull policy
+  pullPolicy: IfNotPresent
+
+# restartPolicy -- Pods restart policy
+restartPolicy: Always
+
+# podSecurityContext -- securityContext configuration on Pods
+podSecurityContext: {}
+
+# securityContext -- securityContext configuration on x509-exporter containers
+securityContext:
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# resources -- resources configuration on Pods
+resources: {}
+
+# nodeSelector -- nodeSelector configuration on Pods
+nodeSelector: {}
+
+# tolerations -- tolerations configuration on Pods
+tolerations: []
+
+# affinity -- affinity configuration on Pods
+affinity: {}
+
+# updateStrategy -- updateStrategy configuration on Pods
+updateStrategy: {}
+
+# service.port -- TCP port to expose the exporter on (whether kube-rbac-proxy is enabled or not)
+servicePort: 9090
+
+exporter:
+  # exporter.watchFiles -- Certificate files to watch and export metrics about (PEM encoded X.509)
+  watchFiles: []
+  # exporter.watchDirectories -- Directories to scan for certificates to be watched and exported
+  watchDirectories: []
+  # exporter.watchKubeconfFiles -- Kubeconf files scanned for embedded certificates to export metrics about
+  watchKubeconfFiles: []
+
+rbacProxy:
+  # rbacProxy.enable -- Use kube-rbac-proxy to expose exporters
+  enable: false
+  # rbacProxy.imageRepository -- kube-rbac-proxy image repository
+  imageRepository: quay.io/coreos/kube-rbac-proxy
+  # rbacProxy.imageTag -- kube-rbac-proxy image version
+  imageTag: v0.4.1
+  # rbacProxy.imagePullPolicy -- kube-rbac-proxy image pull policy
+  imagePullPolicy: IfNotPresent
+  # rbacProxy.exporterListenPort -- Listen port for the exporter inside kube-rbac-proxy exposed Pods
+  exporterListenPort: 9091
+
+prometheusServiceMonitor:
+  # prometheusServiceMonitor.create -- Install a ServiceMonitor ressource to scrape this exporter (for prometheus-operator users)
+  create: false
+  # prometheusServiceMonitor.scrapeInterval -- Target scrape interval to be set in the ServiceMonitor
+  scrapeInterval: 60s
+  # prometheusServiceMonitor.extraLabels -- Extra labels to add on ServiceMonitor ressources
+  extraLabels: {}
+
+prometheusRules:
+  # prometheusRules.create -- Install a PrometheusRule ressource to alert on certificate expiration (for prometheus-operator users)
+  create: false
+  # prometheusRules.warningDaysLeft -- Raise a warning alert when this little days are left before a certificate expiration
+  warningDaysLeft: 90
+  # prometheusRules.criticalDaysLeft -- Raise a critical alert when this little days are left before a certificate expiration
+  criticalDaysLeft: 30
+  # prometheusRules.extraLabels -- Extra labels to add on PrometheusRule ressources
+  extraLabels: {}


### PR DESCRIPTION
Add our x509-exporter with support for files, directories, and Kubeconfig read on the host.
kube-rbac-proxy and prometheus-operator CRD ressources are offered as an option.