### PR TITLE
fix(x509-exporter): kube-rbac-proxy image path

### DIFF
--- a/charts/x509-exporter/templates/daemonset.yaml
+++ b/charts/x509-exporter/templates/daemonset.yaml
@@ -84,7 +84,8 @@ spec:
             containerPort: {{ .Values.servicePort }}
     {{- else }}
         - name: kube-rbac-proxy
-          image: "{{ .Values.rbacProxy.repository }}:{{ .Values.rbacProxy.version }}"
+          image: "{{ .Values.rbacProxy.imageRepository }}:{{ .Values.rbacProxy.imageTag }}"
+          imagePullPolicy: {{ .Values.rbacProxy.imagePullPolicy }}
           args:
           - --logtostderr
           - -v=99


### PR DESCRIPTION
kube-rbac-proxy repository and tag variables in DS template did
not match variable names offered in default values for the Chart