### PR TITLE
[netbox] Fix indentation of resources, nodeSelector, affinity and tolerations

### DIFF
--- a/charts/netbox/templates/_netbox.tpl
+++ b/charts/netbox/templates/_netbox.tpl
@@ -28,7 +28,7 @@ template:
         image: "{{ .Values.image.repository }}:{{ include "netbox.imageTag" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
-          {{- toYaml .Values.resources | indent 12 }}
+          {{- toYaml .Values.resources | nindent 10 }}
         envFrom:
         - configMapRef:
             name: {{ include "netbox.env.configMapName" . | quote }}
@@ -119,15 +119,15 @@ template:
     restartPolicy: {{ .Values.restartPolicy }}
     {{- with .Values.nodeSelector }}
     nodeSelector:
-    {{- toYaml . | indent 4  }}
+    {{- toYaml . | nindent 6  }}
     {{- end }}
     {{- with .Values.affinity }}
     affinity:
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.tolerations }}
     tolerations:
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 6 }}
     {{- end }}
     volumes:
     {{- range $volume := .Values.extraVolumes }}


### PR DESCRIPTION
The definitions for **resource**, **nodeSelector**, **affinity** and **tolerations** can not be set through the values for the helm chart. For example, trying to set the following resource constraints in the values.yaml:

```
---
resources:
  limits:
    cpu: "1"
    memory: 500Mi
  requests:
    cpu: "200m"
    memory: 500Mi
```

results in this error message during the rendering of the templates:

```
$ helm template netbox enix/netbox --values values.yaml 
Error: YAML parse error on netbox/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 34: mapping values are not allowed in this context
```

This PR fixes this issues by using the function `nindent` which prepends a newline in front of the string. Additionally, the number of indentation spaces is corrected.