### PR TITLE
feat(x509-certificate-exporter): add hostNetwork mode support

### DIFF
--- a/charts/x509-certificate-exporter/Chart.yaml
+++ b/charts/x509-certificate-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: x509-certificate-exporter
-version: 1.7.0
+version: 1.8.0
 # when bumping appVersion, change the annotation too (manual for now)
 appVersion: 2.6.1
 type: application

--- a/charts/x509-certificate-exporter/README.md
+++ b/charts/x509-certificate-exporter/README.md
@@ -364,10 +364,9 @@ in the container namespace.
 | secretsExporter.strategy | object | `{}` | DeploymentStrategy for the TLS Secrets exporter |
 | secretsExporter.tolerations | list | `[]` | Toleration for Pods of the TLS Secrets exporter |
 | service.annotations | object | `{}` | Annotations to add to the Service |
-| service.create | bool | `true` | Should a Service be installed (required for ServiceMonitor) |
+| service.create | bool | `true` | Should a headless Service be installed, targets all instances Deployment and DaemonSets (required for ServiceMonitor) |
 | service.extraLabels | object | `{}` | Extra labels to add to the Service |
 | service.port | int | `9793` | TCP port to expose the Service on |
-| service.type | string | `"ClusterIP"` | Service type |
 
 ## ⚖️ License
 

--- a/charts/x509-certificate-exporter/README.md
+++ b/charts/x509-certificate-exporter/README.md
@@ -366,7 +366,6 @@ in the container namespace.
 | service.annotations | object | `{}` | Annotations to add to the Service |
 | service.create | bool | `true` | Should a Service be installed (required for ServiceMonitor) |
 | service.extraLabels | object | `{}` | Extra labels to add to the Service |
-| service.nodePort | string | `nil` | K8S node TCP port to expose the Service on. Relevant only when service.type is "NodePort" or "LoadBalancer" |
 | service.port | int | `9793` | TCP port to expose the Service on |
 | service.type | string | `"ClusterIP"` | Service type |
 

--- a/charts/x509-certificate-exporter/README.md
+++ b/charts/x509-certificate-exporter/README.md
@@ -294,6 +294,7 @@ in the container namespace.
 |-----|------|---------|-------------|
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` | String to fully override x509-certificate-exporter.fullname template with a string |
+| hostNetwork | bool | `false` | Enable hostNetwork mode. Useful when Prometheus is deployed outside of the Kubernetes cluster |
 | hostPathsExporter.affinity | object | `{}` | Affinity for Pods of hostPath exporters (default for all hostPathsExporter.daemonSets) |
 | hostPathsExporter.daemonSets | object | `{}` | [SEE README] Map to define one or many DaemonSets running hostPath exporters. Key is used as a name ; value is a map to override all default settings set by `hostPathsExporter.*`. |
 | hostPathsExporter.debugMode | bool | `false` | Should debug messages be produced by hostPath exporters (default for all hostPathsExporter.daemonSets) |

--- a/charts/x509-certificate-exporter/templates/daemonset.yaml
+++ b/charts/x509-certificate-exporter/templates/daemonset.yaml
@@ -130,6 +130,7 @@ spec:
         {{- . | toYaml | trim | nindent 10 }}
       {{- end }}
     {{- end }}
+      hostNetwork: {{ $.Values.hostNetwork }}
       volumes:
     {{- range default $.Values.hostPathsExporter.watchDirectories $dsDef.watchDirectories }}
       - name: dir-{{ . | clean | sha1sum }}

--- a/charts/x509-certificate-exporter/templates/service.yaml
+++ b/charts/x509-certificate-exporter/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "x509-certificate-exporter.fullname" . }}
+  name: {{ include "x509-certificate-exporter.fullname" . }}-headless
   labels:
     {{- include "x509-certificate-exporter.labels" . | nindent 4 }}
     {{- with .Values.extraLabels }}
@@ -16,8 +16,8 @@ metadata:
     {{- . | toYaml | trim | nindent 4 }}
 {{- end }}
 spec:
+  type: ClusterIP
   clusterIP: None
-  type: {{ .Values.service.type }}
   ports:
   - name: metrics
     port: {{ .Values.service.port }}

--- a/charts/x509-certificate-exporter/templates/service.yaml
+++ b/charts/x509-certificate-exporter/templates/service.yaml
@@ -16,17 +16,12 @@ metadata:
     {{- . | toYaml | trim | nindent 4 }}
 {{- end }}
 spec:
-  {{- if not .Values.service.nodePort }}
   clusterIP: None
-  {{- end }}
   type: {{ .Values.service.type }}
   ports:
   - name: metrics
     port: {{ .Values.service.port }}
     targetPort: metrics
-    {{- with .Values.service.nodePort }}
-    nodePort: {{ . }}
-    {{- end }}
   selector:
     {{- include "x509-certificate-exporter.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/x509-certificate-exporter/templates/service.yaml
+++ b/charts/x509-certificate-exporter/templates/service.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- . | toYaml | trim | nindent 4 }}
 {{- end }}
 spec:
+  {{- if not .Values.service.nodePort }}
+  clusterIP: None
+  {{- end }}
   type: {{ .Values.service.type }}
   ports:
   - name: metrics

--- a/charts/x509-certificate-exporter/values.yaml
+++ b/charts/x509-certificate-exporter/values.yaml
@@ -191,10 +191,8 @@ rbacProxy:
       - ALL
 
 service:
-  # -- Should a Service be installed (required for ServiceMonitor)
+  # -- Should a headless Service be installed, targets all instances Deployment and DaemonSets (required for ServiceMonitor)
   create: true
-  # -- Service type
-  type: ClusterIP
   # -- TCP port to expose the Service on
   port: 9793
   # -- Annotations to add to the Service

--- a/charts/x509-certificate-exporter/values.yaml
+++ b/charts/x509-certificate-exporter/values.yaml
@@ -204,6 +204,9 @@ service:
   # -- Extra labels to add to the Service
   extraLabels: {}
 
+# -- Enable hostNetwork mode. Useful when Prometheus is deployed outside of the Kubernetes cluster
+hostNetwork: false
+
 prometheusServiceMonitor:
   # -- Should a ServiceMonitor ressource be installed to scrape this exporter. For prometheus-operator (kube-prometheus) users.
   create: true

--- a/charts/x509-certificate-exporter/values.yaml
+++ b/charts/x509-certificate-exporter/values.yaml
@@ -197,8 +197,6 @@ service:
   type: ClusterIP
   # -- TCP port to expose the Service on
   port: 9793
-  # -- K8S node TCP port to expose the Service on. Relevant only when service.type is "NodePort" or "LoadBalancer"
-  nodePort: null
   # -- Annotations to add to the Service
   annotations: {}
   # -- Extra labels to add to the Service


### PR DESCRIPTION
hey @Zempashi @npdgm 

one more PR, adding `hostNetwork` mode support and making Service truly "headless"

Let me shortly describe my _need_ so you'll understand the reason of the PRs.

We have a standalone baremetal Prometheus deployment, i.e. outside of the K8S cluster (also baremetal) on a separate host. Thus initially, in order to reach the x509 cert exporter, I've added a nodePort Service support in my previous PR and then realized that Prometheus must collect exporter data via `endpoints` K8S SD rather than `service` SD which was solved by adding `hostNetwork` mode support, ending up with the setup pretty much similar to the node_exporter, hence this PR.

Also I've made Service really headless as per [K8S docs](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services), because in the end we do not need a ClusterIP allocation for it.

Couple of questions assuming the above:
- Is it worth to remove `NodePort` support altogether to avoid any confusion in the future, essentially rolling back the changes from my previous PR?
- ⚠️⚠️⚠️ Upgrade of any existing chart release with the changes from this PR will cause the following expected error:
  ```
  Error: UPGRADE FAILED: cannot patch "x509-certificate-exporter" with kind Service: Service "x509-certificate-exporter" is invalid: spec.clusterIP: Invalid value: "None": field is immutable
  ```
  which must be tackled manually. What would be your preference here? Should this be mentioned in the README or you don't want that `ClusterIP` related change at all?
