### PR TITLE
x509-certificate-exporter: improve sensible defaults for resources

### DIFF
--- a/charts/x509-certificate-exporter/values.yaml
+++ b/charts/x509-certificate-exporter/values.yaml
@@ -71,7 +71,7 @@ secretsExporter:
   resources:
     limits:
       cpu: 200m
-      memory: 40Mi
+      memory: 100Mi
     requests:
       cpu: 10m
       memory: 20Mi


### PR DESCRIPTION
Defaults for resources requests and limits may not be adequate especially with the Secrets exporter Pod. On a modest cluster I've seen cases of OOM killing happening from time to time.

A Guaranteed class with too much requested memory doesn't look like a good sensible default, it should be up to users to decide if Burstable resources on an exporter are not good enough.
However I'm bumping the memory limit as it seems inadequate.

@arcln is there a way to better tune our default resources, perhaps a rule of thumb formula for how many Secrets are being scanned? I don't know if we're O(1) or O(n) with Kubernetes resources.