### PR TITLE
x509-certificate-exporter: release chart 1.13.1, exporter 2.9.1

### DIFF
--- a/charts/x509-certificate-exporter/Chart.yaml
+++ b/charts/x509-certificate-exporter/Chart.yaml
@@ -4,9 +4,9 @@
 version: 1.13.0
 # when bumping appVersion, please:
 # - update the "images" annotation
-appVersion: 2.9.0
+appVersion: 2.9.1
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/prerelease: "false"
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
@@ -17,7 +17,7 @@ annotations:
     - "Helm template refactoring and style changes"
   artifacthub.io/images: |
     - name: x509-certificate-exporter
-      image: enix/x509-certificate-exporter:2.9.0
+      image: enix/x509-certificate-exporter:2.9.1
     - name: kube-rbac-proxy
       image: quay.io/coreos/kube-rbac-proxy:v0.5.0
       whitelisted: true

--- a/charts/x509-certificate-exporter/Chart.yaml
+++ b/charts/x509-certificate-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 # when bumping version, please:
 # - replace the "changes" annotation with new content
 # - update "containsSecurityUpdates" if needed
-version: 1.13.0
+version: 1.13.1
 # when bumping appVersion, please:
 # - update the "images" annotation
 appVersion: 2.9.1
@@ -10,11 +10,9 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
-    - "exporter: Base image update (fixes security scan warnings)"
-    - "Add support for metric labels filtering (new in exporter v2.9.0)"
-    - "Detect Kubernetes version and guess best apiVersion for Deployment and RBAC"
-    - "Fix missing labels on Pods"
-    - "Helm template refactoring and style changes"
+    - "exporter: Fix metric labels filtering not effective"
+    - "Fix metric labels filtering not applied to DaemonSets"
+    - "Allow empty list for metric labels filtering"
   artifacthub.io/images: |
     - name: x509-certificate-exporter
       image: enix/x509-certificate-exporter:2.9.1

--- a/charts/x509-certificate-exporter/README.md
+++ b/charts/x509-certificate-exporter/README.md
@@ -324,7 +324,7 @@ in the container namespace.
 | podExtraLabels | object | `{}` | Extra labels added to all Pods |
 | podAnnotations | object | `{}` | Annotations added to all Pods |
 | exposeRelativeMetrics | bool | `false` | Enable additional metrics with relative durations instead of absolute timestamps ; not recommended with Prometheus |
-| metricLabelsFilterList | list | `nil` | Restrict metric labels to this list if set ; helps with cardinality constraining systems such as Datadog |
+| metricLabelsFilterList | list | `nil` | Restrict metric labels to this list if set. **Warning** : use with caution as reducing cardinality may yield metrics collisions and force the exporter to ignore certificates. This will also degrade the usability of the Grafana dashboard. This list should always include at least `filepath`, `secret_namespace` and `secret_name`. Also `subject_CN` is highly recommended for when a file contains multiple certificates. |
 | secretsExporter.enabled | bool | `true` | Should the TLS Secrets exporter be running |
 | secretsExporter.debugMode | bool | `false` | Should debug messages be produced by the TLS Secrets exporter |
 | secretsExporter.replicas | int | `1` | Desired number of TLS Secrets exporter Pod |

--- a/charts/x509-certificate-exporter/README.md
+++ b/charts/x509-certificate-exporter/README.md
@@ -324,7 +324,7 @@ in the container namespace.
 | podExtraLabels | object | `{}` | Extra labels added to all Pods |
 | podAnnotations | object | `{}` | Annotations added to all Pods |
 | exposeRelativeMetrics | bool | `false` | Enable additional metrics with relative durations instead of absolute timestamps ; not recommended with Prometheus |
-| metricLabelsFilterList | list | `[]` | Restrict metric labels to this list if set ; helps with cardinality constraining systems such as Datadog |
+| metricLabelsFilterList | list | `nil` | Restrict metric labels to this list if set ; helps with cardinality constraining systems such as Datadog |
 | secretsExporter.enabled | bool | `true` | Should the TLS Secrets exporter be running |
 | secretsExporter.debugMode | bool | `false` | Should debug messages be produced by the TLS Secrets exporter |
 | secretsExporter.replicas | int | `1` | Desired number of TLS Secrets exporter Pod |

--- a/charts/x509-certificate-exporter/templates/daemonset.yaml
+++ b/charts/x509-certificate-exporter/templates/daemonset.yaml
@@ -82,6 +82,9 @@ spec:
         {{- range default $.Values.hostPathsExporter.watchKubeconfFiles $dsDef.watchKubeconfFiles }}
         - --watch-kubeconf=/mnt/watch/kube-{{ . | clean | sha1sum }}/{{ . | clean }}
         {{- end }}
+        {{- if not (kindIs "invalid" .Values.metricLabelsFilterList) }}
+        - --expose-labels={{ .Values.metricLabelsFilterList | join "," }}
+        {{- end }}
         volumeMounts:
         {{- range default $.Values.hostPathsExporter.watchDirectories $dsDef.watchDirectories }}
         - name: dir-{{ . | clean | sha1sum }}

--- a/charts/x509-certificate-exporter/templates/deployment.yaml
+++ b/charts/x509-certificate-exporter/templates/deployment.yaml
@@ -93,8 +93,8 @@ spec:
         {{- range .Values.secretsExporter.excludeLabels }}
         - --exclude-label={{ . | trim }}
         {{- end }}
-        {{- with .Values.metricLabelsFilterList }}
-        - --expose-labels={{ . | join "," }}
+        {{- if not (kindIs "invalid" .Values.metricLabelsFilterList) }}
+        - --expose-labels={{ .Values.metricLabelsFilterList | join "," }}
         {{- end }}
       {{- if not .Values.rbacProxy.enabled }}
         - --port={{ .Values.podListenPort }}

--- a/charts/x509-certificate-exporter/values.yaml
+++ b/charts/x509-certificate-exporter/values.yaml
@@ -63,7 +63,7 @@ podAnnotations: {}
 # -- Enable additional metrics with relative durations instead of absolute timestamps ; not recommended with Prometheus
 exposeRelativeMetrics: false
 
-# -- (list) Restrict metric labels to this list if set ; helps with cardinality constraining systems such as Datadog
+# -- (list) Restrict metric labels to this list if set. **Warning** : use with caution as reducing cardinality may yield metrics collisions and force the exporter to ignore certificates. This will also degrade the usability of the Grafana dashboard. This list should always include at least `filepath`, `secret_namespace` and `secret_name`. Also `subject_CN` is highly recommended for when a file contains multiple certificates.
 metricLabelsFilterList: null
 
 secretsExporter:

--- a/charts/x509-certificate-exporter/values.yaml
+++ b/charts/x509-certificate-exporter/values.yaml
@@ -63,8 +63,8 @@ podAnnotations: {}
 # -- Enable additional metrics with relative durations instead of absolute timestamps ; not recommended with Prometheus
 exposeRelativeMetrics: false
 
-# -- Restrict metric labels to this list if set ; helps with cardinality constraining systems such as Datadog
-metricLabelsFilterList: []
+# -- (list) Restrict metric labels to this list if set ; helps with cardinality constraining systems such as Datadog
+metricLabelsFilterList: null
 
 secretsExporter:
   # -- Should the TLS Secrets exporter be running


### PR DESCRIPTION
Fixes issues with labels filtering, both in the exporter and chart