### PR TITLE
kube-router: compatibility with Kubernetes >=1.22

### DIFF
--- a/charts/kube-router/Chart.yaml
+++ b/charts/kube-router/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-router
 description: A turnkey solution for Kubernetes networking with aim to provide operational simplicity and high performance.
 type: application
-version: 1.5.2
+version: 1.5.3
 appVersion: v1.3.2
 
 icon: https://cdn.rawgit.com/cloudnativelabs/kube-router/64f7700e/Documentation/img/logo-full.svg

--- a/charts/kube-router/templates/_capabilities.tpl
+++ b/charts/kube-router/templates/_capabilities.tpl
@@ -1,0 +1,17 @@
+{{/*
+Return the target Kubernetes version
+*/}}
+{{- define "capabilities.kubeVersion" -}}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for RBAC resources.
+*/}}
+{{- define "capabilities.rbac.apiVersion" -}}
+{{- if semverCompare "<1.17-0" (include "capabilities.kubeVersion" .) -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kube-router/templates/clusterrole.yaml
+++ b/charts/kube-router/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ include "capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "kube-router.fullname" . }}
   labels:

--- a/charts/kube-router/templates/clusterrolebinding.yaml
+++ b/charts/kube-router/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ include "capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "kube-router.fullname" . }}
   labels:


### PR DESCRIPTION
Introduce a new release with auto-detection of suitable apiversion for RBAC resources.
Backward compatibility with older clusters is preserved.

Fixes #71 