### PR TITLE
fix(cnpg-cluster): Properly handle bool value for resizeInUseVolumes

### DIFF
--- a/charts/cnpg-cluster/templates/cluster.cnpg.yaml
+++ b/charts/cnpg-cluster/templates/cluster.cnpg.yaml
@@ -37,8 +37,8 @@ spec:
 
   storage:
     size: {{ .Values.persistence.size | quote }}
-    {{- with .Values.persistence.resizeInUseVolumes }}
-    resizeInUseVolumes: {{ . | quote }}
+    {{- if not (eq .Values.persistence.resizeInUseVolumes nil) }}
+    resizeInUseVolumes: {{ .Values.persistence.resizeInUseVolumes | quote }}
     {{- end }}
     {{- if .Values.persistence.storageClass }}
     {{- if (eq "-" .Values.persistence.storageClass) }}


### PR DESCRIPTION
If we set persistence.resizeInUseVolumes value to false, this was never added to CR as it's considered as an empty value and so 'with' section was skipped. So check if a value is provided instead.